### PR TITLE
Remove Embedded Reflect Types in Parser Types

### DIFF
--- a/argument.go
+++ b/argument.go
@@ -8,9 +8,12 @@ import (
 func NewArgument(parserArg *parser.Argument, builder *SchemaBuilder) *graphql.ArgumentConfig {
 	graphqlType := getOrCreateType(parserArg.ArgType(), builder)
 	argument := &graphql.ArgumentConfig{
-		Type:         graphqlType,
-		Description:  parserArg.Description(),
-		DefaultValue: parserArg.DefaultValue(),
+		Type:        graphqlType,
+		Description: parserArg.Description(),
+	}
+
+	if parserArg.DefaultValue() != "" {
+		argument.DefaultValue = parserArg.DefaultValue()
 	}
 
 	return argument

--- a/enum.go
+++ b/enum.go
@@ -10,8 +10,8 @@ import (
 type EnumType = parser.EnumType
 
 func NewEnum(t *parser.Enum, builder *SchemaBuilder) *graphql.Enum {
-	name := t.Name()
-	enumType := reflect.New(t.Type).Interface().(EnumType)
+	name := t.ReflectType().Name()
+	enumType := reflect.New(t.ReflectType()).Interface().(EnumType)
 
 	values := graphql.EnumValueConfigMap{}
 	for _, value := range enumType.Values() {

--- a/field.go
+++ b/field.go
@@ -16,15 +16,16 @@ func NewField(parserField *parser.Field, builder *SchemaBuilder) *graphql.Field 
 	// default resolver
 	resolver = func(p graphql.ResolveParams) (interface{}, error) {
 		value := reflect.ValueOf(p.Source)
+		name := parserField.StructField().Name
 		if value.Type().Kind() == reflect.Ptr {
 			value = value.Elem()
 		}
 
 		if _, ok := parserField.Type().(*parser.Enum); ok {
-			return value.FieldByName(parserField.Name).Convert(reflect.TypeOf("")).Interface(), nil
+			return value.FieldByName(name).Convert(reflect.TypeOf("")).Interface(), nil
 		}
 
-		return value.FieldByName(parserField.Name).Interface(), nil
+		return value.FieldByName(name).Interface(), nil
 	}
 
 	if parserField.Subscriber() != nil {

--- a/field.go
+++ b/field.go
@@ -20,6 +20,10 @@ func NewField(parserField *parser.Field, builder *SchemaBuilder) *graphql.Field 
 			value = value.Elem()
 		}
 
+		if _, ok := parserField.Type().(*parser.Enum); ok {
+			return value.FieldByName(parserField.Name).Convert(reflect.TypeOf("")).Interface(), nil
+		}
+
 		return value.FieldByName(parserField.Name).Interface(), nil
 	}
 

--- a/input_object.go
+++ b/input_object.go
@@ -8,7 +8,7 @@ import (
 func NewInputObject(input *parser.Input, builder *SchemaBuilder) *graphql.InputObject {
 	// TODO: description
 	object := graphql.NewInputObject(graphql.InputObjectConfig{
-		Name:   input.Name(),
+		Name:   input.ReflectType().Name(),
 		Fields: graphql.InputObjectConfigFieldMap{},
 	})
 

--- a/input_object.go
+++ b/input_object.go
@@ -14,11 +14,16 @@ func NewInputObject(input *parser.Input, builder *SchemaBuilder) *graphql.InputO
 
 	builder.addType(input, object)
 	for _, arg := range input.Arguments() {
-		object.AddFieldConfig(arg.JSONName(), &graphql.InputObjectFieldConfig{
-			Type:         NewArgument(arg, builder).Type,
-			Description:  arg.Description(),
-			DefaultValue: arg.DefaultValue(),
-		})
+		config := &graphql.InputObjectFieldConfig{
+			Type:        NewArgument(arg, builder).Type,
+			Description: arg.Description(),
+		}
+
+		if arg.DefaultValue() != "" {
+			config.DefaultValue = arg.DefaultValue()
+		}
+
+		object.AddFieldConfig(arg.JSONName(), config)
 	}
 
 	return object

--- a/object.go
+++ b/object.go
@@ -11,7 +11,7 @@ func NewObject(parserObject *parser.Object, builder *SchemaBuilder) *graphql.Obj
 	fields := graphql.Fields{}
 
 	object := graphql.NewObject(graphql.ObjectConfig{
-		Name:       parserObject.Name(),
+		Name:       parserObject.ReflectType().Name(),
 		Interfaces: interfaces,
 		Fields:     fields,
 	})

--- a/parser/argument.go
+++ b/parser/argument.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Argument struct {
-	reflect.StructField
+	structField  reflect.StructField
 	input        *Input
 	type_        Type
 	jsonName     string
@@ -20,7 +20,7 @@ func NewArgument(input *Input, field reflect.StructField) (*Argument, error) {
 	}
 
 	argument := &Argument{
-		StructField:  field,
+		structField:  field,
 		input:        input,
 		description:  field.Tag.Get("description"),
 		jsonName:     field.Tag.Get("json"),
@@ -57,7 +57,7 @@ func (arg *Argument) JSONName() string {
 		return arg.jsonName
 	}
 
-	return arg.Name
+	return arg.structField.Name
 }
 
 func (arg *Argument) DefaultValue() string {
@@ -67,7 +67,7 @@ func (arg *Argument) DefaultValue() string {
 func (arg *Argument) ImplementsType() {}
 
 func validateArgumentType(arg *Argument) error {
-	kind, err := getTypeKind(arg.Type)
+	kind, err := getTypeKind(arg.structField.Type)
 	if err != nil {
 		return err
 	}
@@ -76,9 +76,9 @@ func validateArgumentType(arg *Argument) error {
 	case KindInterface, KindUnion, KindInterfaceDefinition:
 		return fmt.Errorf(
 			"argument type %s not supported for field %s on struct %s \nif you think this is a mistake please open an issue at github.com/shreyas44/groot",
-			arg.StructField.Type.Name(),
-			arg.StructField.Name,
-			arg.Input().Name(),
+			arg.structField.Type.Name(),
+			arg.structField.Name,
+			arg.Input().reflectType.Name(),
 		)
 	}
 

--- a/parser/array.go
+++ b/parser/array.go
@@ -3,8 +3,8 @@ package parser
 import "reflect"
 
 type Array struct {
-	reflect.Type
-	element Type
+	reflectType reflect.Type
+	element     Type
 }
 
 func NewArray(t reflect.Type, isArgument bool) (*Array, error) {
@@ -34,5 +34,5 @@ func (a *Array) Element() Type {
 }
 
 func (a *Array) ReflectType() reflect.Type {
-	return a.Type
+	return a.reflectType
 }

--- a/parser/enum.go
+++ b/parser/enum.go
@@ -3,8 +3,8 @@ package parser
 import "reflect"
 
 type Enum struct {
-	reflect.Type
-	values []string
+	reflectType reflect.Type
+	values      []string
 }
 
 func NewEnum(t reflect.Type) (*Enum, error) {
@@ -27,5 +27,5 @@ func (e *Enum) Values() []string {
 }
 
 func (e *Enum) ReflectType() reflect.Type {
-	return e.Type
+	return e.reflectType
 }

--- a/parser/field.go
+++ b/parser/field.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Field struct {
-	reflect.StructField
+	structField       reflect.StructField
 	fieldType         Type
 	object            TypeWithFields
 	arguments         []*Argument
@@ -29,7 +29,7 @@ func NewField(t TypeWithFields, field reflect.StructField) (*Field, error) {
 		fieldType   Type
 		err         error
 		objectField = &Field{
-			StructField:       field,
+			structField:       field,
 			object:            t,
 			description:       field.Tag.Get("description"),
 			jsonName:          field.Tag.Get("json"),
@@ -47,7 +47,7 @@ func NewField(t TypeWithFields, field reflect.StructField) (*Field, error) {
 		return nil, err
 	}
 
-	if t.Name() == "Subscription" {
+	if t.ReflectType().Name() == "Subscription" {
 		if subscriber, err = NewResolver(objectField); err != nil {
 			return nil, err
 		}
@@ -101,10 +101,14 @@ func (f *Field) Description() string {
 
 func (f *Field) JSONName() string {
 	if f.jsonName == "" {
-		return f.Name
+		return f.structField.Name
 	}
 
 	return f.jsonName
+}
+
+func (f *Field) StructField() reflect.StructField {
+	return f.structField
 }
 
 func (f *Field) DeprecationReason() string {

--- a/parser/input.go
+++ b/parser/input.go
@@ -5,8 +5,8 @@ import (
 )
 
 type Input struct {
-	reflect.Type
-	arguments []*Argument
+	reflectType reflect.Type
+	arguments   []*Argument
 }
 
 func NewInput(t reflect.Type) (*Input, error) {
@@ -15,8 +15,8 @@ func NewInput(t reflect.Type) (*Input, error) {
 	}
 
 	input := &Input{
-		Type:      t,
-		arguments: []*Argument{},
+		reflectType: t,
+		arguments:   []*Argument{},
 	}
 
 	cache.set(t, input)
@@ -35,7 +35,7 @@ func (i *Input) Arguments() []*Argument {
 }
 
 func (i *Input) ReflectType() reflect.Type {
-	return i.Type
+	return i.reflectType
 }
 
 func getArguments(t *Input, reflectType reflect.Type) ([]*Argument, error) {

--- a/parser/interface.go
+++ b/parser/interface.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Interface struct {
-	reflect.Type
-	fields []*Field
+	reflectType reflect.Type
+	fields      []*Field
 }
 
 func NewInterface(t reflect.Type) (*Interface, error) {
@@ -35,7 +35,7 @@ func NewInterfaceFromDefinition(t reflect.Type) (*Interface, error) {
 	}
 
 	interface_ := &Interface{
-		Type: t,
+		reflectType: t,
 	}
 
 	cache.set(t, interface_)
@@ -50,7 +50,7 @@ func NewInterfaceFromDefinition(t reflect.Type) (*Interface, error) {
 }
 
 func (i *Interface) Name() string {
-	name := i.Type.Name()
+	name := i.reflectType.Name()
 	name = name[:len(name)-len("Definition")]
 	return name
 }
@@ -60,7 +60,7 @@ func (i *Interface) Fields() []*Field {
 }
 
 func (i *Interface) ReflectType() reflect.Type {
-	return i.Type
+	return i.reflectType
 }
 
 func validateInterface(t reflect.Type) error {

--- a/parser/nullable.go
+++ b/parser/nullable.go
@@ -5,8 +5,8 @@ import (
 )
 
 type Nullable struct {
-	reflect.Type
-	element Type
+	reflectType reflect.Type
+	element     Type
 }
 
 func NewNullable(t reflect.Type, isArgument bool) (*Nullable, error) {
@@ -36,5 +36,5 @@ func (n *Nullable) Element() Type {
 }
 
 func (n *Nullable) ReflectType() reflect.Type {
-	return n.Type
+	return n.reflectType
 }

--- a/parser/object.go
+++ b/parser/object.go
@@ -3,16 +3,16 @@ package parser
 import "reflect"
 
 type Object struct {
-	reflect.Type
-	fields     []*Field
-	interfaces []*Interface
+	reflectType reflect.Type
+	fields      []*Field
+	interfaces  []*Interface
 }
 
 func NewObject(t reflect.Type) (*Object, error) {
 	object := &Object{
-		Type:       t,
-		fields:     []*Field{},
-		interfaces: []*Interface{},
+		reflectType: t,
+		fields:      []*Field{},
+		interfaces:  []*Interface{},
 	}
 
 	if err := validateTypeKind(t, KindObject); err != nil {
@@ -46,7 +46,7 @@ func (o *Object) Interfaces() []*Interface {
 }
 
 func (o *Object) ReflectType() reflect.Type {
-	return o.Type
+	return o.reflectType
 }
 
 func getFields(t TypeWithFields, reflectType reflect.Type) ([]*Field, error) {
@@ -81,8 +81,8 @@ func getFields(t TypeWithFields, reflectType reflect.Type) ([]*Field, error) {
 func getInterfaces(object *Object) ([]*Interface, error) {
 	interfaces := []*Interface{}
 
-	for i := 0; i < object.Type.NumField(); i++ {
-		field := object.Type.Field(i)
+	for i := 0; i < object.reflectType.NumField(); i++ {
+		field := object.reflectType.Field(i)
 
 		if field.Anonymous {
 			interfaceType, err := getOrCreateType(field.Type)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -27,7 +27,6 @@ var (
 )
 
 type Type interface {
-	reflect.Type
 	ReflectType() reflect.Type
 }
 
@@ -51,12 +50,12 @@ var (
 )
 
 func ParseObject(t reflect.Type) (*Object, error) {
-	t, err := getOrCreateType(t)
+	grootType, err := getOrCreateType(t)
 	if err != nil {
 		return nil, err
 	}
 
-	if object, ok := t.(*Object); ok {
+	if object, ok := grootType.(*Object); ok {
 		return object, nil
 	}
 
@@ -64,12 +63,12 @@ func ParseObject(t reflect.Type) (*Object, error) {
 }
 
 func ParseInputObject(t reflect.Type) (*Input, error) {
-	t, err := getOrCreateArgumentType(t)
+	grootType, err := getOrCreateArgumentType(t)
 	if err != nil {
 		return nil, err
 	}
 
-	if inputObject, ok := t.(*Input); ok {
+	if inputObject, ok := grootType.(*Input); ok {
 		return inputObject, nil
 	}
 
@@ -77,12 +76,12 @@ func ParseInputObject(t reflect.Type) (*Input, error) {
 }
 
 func ParseUnion(t reflect.Type) (*Union, error) {
-	t, err := getOrCreateType(t)
+	grootType, err := getOrCreateType(t)
 	if err != nil {
 		return nil, err
 	}
 
-	if union, ok := t.(*Union); ok {
+	if union, ok := grootType.(*Union); ok {
 		return union, nil
 	}
 
@@ -90,12 +89,12 @@ func ParseUnion(t reflect.Type) (*Union, error) {
 }
 
 func ParseInterface(t reflect.Type) (*Interface, error) {
-	t, err := getOrCreateType(t)
+	grootType, err := getOrCreateType(t)
 	if err != nil {
 		return nil, err
 	}
 
-	if interfaceType, ok := t.(*Interface); ok {
+	if interfaceType, ok := grootType.(*Interface); ok {
 		return interfaceType, nil
 	}
 
@@ -103,12 +102,12 @@ func ParseInterface(t reflect.Type) (*Interface, error) {
 }
 
 func ParseScalar(t reflect.Type) (*Scalar, error) {
-	t, err := getOrCreateType(t)
+	grootType, err := getOrCreateType(t)
 	if err != nil {
 		return nil, err
 	}
 
-	if scalar, ok := t.(*Scalar); ok {
+	if scalar, ok := grootType.(*Scalar); ok {
 		return scalar, nil
 	}
 
@@ -116,12 +115,12 @@ func ParseScalar(t reflect.Type) (*Scalar, error) {
 }
 
 func ParseEnum(t reflect.Type) (*Enum, error) {
-	t, err := getOrCreateType(t)
+	grootType, err := getOrCreateType(t)
 	if err != nil {
 		return nil, err
 	}
 
-	if enum, ok := t.(*Enum); ok {
+	if enum, ok := grootType.(*Enum); ok {
 		return enum, nil
 	}
 

--- a/parser/resolver.go
+++ b/parser/resolver.go
@@ -31,7 +31,7 @@ type Resolver struct {
 func NewResolver(field *Field) (*Resolver, error) {
 	var (
 		methodName string
-		fieldName  = field.JSONName()
+		fieldName  = field.structField.Name
 		object     = field.Object().ReflectType()
 	)
 

--- a/parser/scalar.go
+++ b/parser/scalar.go
@@ -10,7 +10,7 @@ const (
 )
 
 type Scalar struct {
-	reflect.Type
+	reflectType reflect.Type
 }
 
 func NewScalar(t reflect.Type) (*Scalar, error) {
@@ -18,11 +18,11 @@ func NewScalar(t reflect.Type) (*Scalar, error) {
 		panic(err)
 	}
 
-	scalar := &Scalar{Type: t}
+	scalar := &Scalar{t}
 	cache.set(t, scalar)
 	return scalar, nil
 }
 
 func (s Scalar) ReflectType() reflect.Type {
-	return s.Type
+	return s.reflectType
 }

--- a/parser/union.go
+++ b/parser/union.go
@@ -6,17 +6,17 @@ import (
 )
 
 type Union struct {
-	reflect.Type
-	members []*Object
+	reflectType reflect.Type
+	members     []*Object
 }
 
 func NewUnion(t reflect.Type) (*Union, error) {
 	union := &Union{
-		Type:    t,
-		members: []*Object{},
+		reflectType: t,
+		members:     []*Object{},
 	}
 
-	if err := validateTypeKind(union); err != nil {
+	if err := validateTypeKind(union.reflectType); err != nil {
 		panic(err)
 	}
 
@@ -49,12 +49,12 @@ func (u *Union) Members() []*Object {
 }
 
 func (u *Union) ReflectType() reflect.Type {
-	return u.Type
+	return u.reflectType
 }
 
 func validateUnion(t *Union) error {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for i := 0; i < t.reflectType.NumField(); i++ {
+		field := t.reflectType.Field(i)
 		parserType, err := getTypeKind(field.Type)
 		if err != nil {
 			return err
@@ -64,7 +64,7 @@ func validateUnion(t *Union) error {
 			return fmt.Errorf(
 				"got extra field %s on union %s, union types cannot contain any field other than embedded structs and groot.UnionType",
 				field.Name,
-				t.Name(),
+				t.reflectType.Name(),
 			)
 		}
 	}

--- a/resolver.go
+++ b/resolver.go
@@ -125,7 +125,7 @@ func makeResolverArgs(resolver *parser.Resolver, p graphql.ResolveParams) ([]ref
 			}
 
 			json.Unmarshal(jsonBytes, &structInterface)
-			if i := structInterface.(InputValidator); i != nil {
+			if i, ok := structInterface.(InputValidator); ok {
 				if err := i.Validate(); err != nil {
 					return nil, err
 				}

--- a/scalars.go
+++ b/scalars.go
@@ -36,7 +36,7 @@ func NewScalar(parserScalar *parser.Scalar, builder *SchemaBuilder) *graphql.Sca
 
 	// TODO: description
 	scalar := graphql.NewScalar(graphql.ScalarConfig{
-		Name: parserScalar.Name(),
+		Name: parserScalar.ReflectType().Name(),
 		Serialize: func(value interface{}) interface{} {
 			var v ScalarType
 			if reflect.TypeOf(value).Kind() != reflect.Ptr {

--- a/union.go
+++ b/union.go
@@ -20,7 +20,7 @@ func NewUnion(parserUnion *parser.Union, builder *SchemaBuilder) *graphql.Union 
 
 	// TODO: description
 	union := graphql.NewUnion(graphql.UnionConfig{
-		Name:  parserUnion.Name(),
+		Name:  parserUnion.ReflectType().Name(),
 		Types: placeholderTypes,
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			valueType := reflect.TypeOf(p.Value)
@@ -41,7 +41,7 @@ func NewUnion(parserUnion *parser.Union, builder *SchemaBuilder) *graphql.Union 
 
 func resolveUnionValue(union *parser.Union, p graphql.ResolveTypeParams) reflect.Value {
 	for _, member := range union.Members() {
-		name := member.Name()
+		name := member.ReflectType().Name()
 		field := reflect.ValueOf(p.Value).FieldByName(name)
 
 		if !field.IsZero() {
@@ -49,6 +49,6 @@ func resolveUnionValue(union *parser.Union, p graphql.ResolveTypeParams) reflect
 		}
 	}
 
-	firstValue := reflect.ValueOf(p.Value).FieldByName(union.Members()[0].Name())
+	firstValue := reflect.ValueOf(p.Value).FieldByName(union.Members()[0].ReflectType().Name())
 	return firstValue
 }


### PR DESCRIPTION
- Fix default value bug where the default value for fields was the zero value in Go instead of nothing
- Fix resolvers for fields of type enum
- Remove embedded reflect types in parser types